### PR TITLE
Fixed script parsing

### DIFF
--- a/yarn-completion.plugin.zsh
+++ b/yarn-completion.plugin.zsh
@@ -1,4 +1,4 @@
-sed -E 's/\s+"([^"]+)": "(.+)",?/\1=>\2/'_yc_yarn_command() {
+_yc_yarn_command() {
   echo "${words[2]}"
 }
 

--- a/yarn-completion.plugin.zsh
+++ b/yarn-completion.plugin.zsh
@@ -1,4 +1,4 @@
-_yc_yarn_command() {
+sed -E 's/\s+"([^"]+)": "(.+)",?/\1=>\2/'_yc_yarn_command() {
   echo "${words[2]}"
 }
 
@@ -30,7 +30,7 @@ _yc_get_package_json_property_object() {
   cat "$package_json" |
     sed -nE "/^ *\"$property\": \{$/,/^ *\},?$/p" | # Grab scripts object
     sed '1d;$d' |                                   # Remove first/last lines
-    sed -E 's/( )+"([^"]+)": "(.+)",?/\2=>\3/'      # Parse into key=>value
+    sed -E 's/\s+"([^"]+)": "(.+)",?/\1=>\2/'      # Parse into key=>value
 }
 
 _yc_get_package_json_property_object_keys() {

--- a/yarn-completion.plugin.zsh
+++ b/yarn-completion.plugin.zsh
@@ -30,7 +30,7 @@ _yc_get_package_json_property_object() {
   cat "$package_json" |
     sed -nE "/^ *\"$property\": \{$/,/^ *\},?$/p" | # Grab scripts object
     sed '1d;$d' |                                   # Remove first/last lines
-    sed -E 's/    "([^"]+)": "(.+)",?/\1=>\2/'      # Parse into key=>value
+    sed -E 's/( )+"([^"]+)": "(.+)",?/\2=>\3/'      # Parse into key=>value
 }
 
 _yc_get_package_json_property_object_keys() {


### PR DESCRIPTION
When a package.json has the indentation of 4 per line, zsh has some serious problems with it.